### PR TITLE
Add configrable id prefixes

### DIFF
--- a/dss-xades/src/main/java/eu/europa/esig/dss/xades/XAdESIdPrefixes.java
+++ b/dss-xades/src/main/java/eu/europa/esig/dss/xades/XAdESIdPrefixes.java
@@ -1,0 +1,150 @@
+/**
+ * DSS - Digital Signature Services
+ * Copyright (C) 2015 European Commission, provided under the CEF programme
+ *
+ * This file is part of the "DSS - Digital Signature Services" project.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package eu.europa.esig.dss.xades;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+public class XAdESIdPrefixes {
+	private static final String ID_PREFIX = "id-";
+	private static final String TIMESTAMP_PREFIX = "ts-";
+	private static final String ENCAPSULATED_TIMESTAMP_PREFIX = "ets-";
+	private static final String KEYINFO_PREFIX = "keyInfo-";
+	private static final String VALUE_PREFIX = "value-";
+	private static final String XADES_PREFIX = "xades-";
+
+	/** Xml Id prefix */
+	private final String id;
+	/** Id-prefix for TimeStamp element */
+	private final String timestamp;
+	/** Id-prefix for EncapsulatedTimeStamp element */
+	private final String encapsulatedTimestamp;
+	/** Id-prefix for KeyInfo element */
+	private final String keyInfo;
+	/** Id-prefix for SignatureValue element */
+	private final String value;
+	/** Id-prefix for Signature element */
+	private final String xades;
+
+	public String getId() {
+		return id;
+	}
+
+	public String getTimestamp() {
+		return timestamp;
+	}
+
+	public String getEncapsulatedTimestamp() {
+		return encapsulatedTimestamp;
+	}
+
+	public String getKeyInfo() {
+		return keyInfo;
+	}
+
+	public String getValue() {
+		return value;
+	}
+
+	public String getXades() {
+		return xades;
+	}
+
+	public static XAdESIdPrefixes.XAdESIdBuilder newBuilder() {
+		return new XAdESIdPrefixes.XAdESIdBuilder();
+	}
+
+	private XAdESIdPrefixes(XAdESIdBuilder builder) {
+		this.id = builder.id;
+		this.timestamp = builder.timestamp;
+		this.encapsulatedTimestamp = builder.encapsulatedTimestamp;
+		this.keyInfo = builder.keyInfo;
+		this.value = builder.value;
+		this.xades = builder.xades;
+		validate();
+	}
+
+	private void validate() {
+		Set<String> prefixesToValidate = new HashSet<>();
+		prefixesToValidate.add(id);
+		prefixesToValidate.add(timestamp);
+		prefixesToValidate.add(encapsulatedTimestamp);
+		prefixesToValidate.add(keyInfo);
+		prefixesToValidate.add(value);
+		prefixesToValidate.add(xades);
+
+		if (prefixesToValidate.size() != 6) {
+			throw new IllegalArgumentException("All prefixes needs to be unique!");
+		}
+		// Regular expression pattern to match illegal XML characters
+		Pattern illegalXmlCharactersPattern = Pattern.compile("[&<>\"']");
+
+		for (String prefix : prefixesToValidate) {
+			if (illegalXmlCharactersPattern.matcher(prefix).find()) {
+				throw new IllegalArgumentException("Id contains invalid XML character: " + prefix);
+			}
+		}
+	}
+
+	public static class XAdESIdBuilder {
+		private String id = ID_PREFIX;
+		private String timestamp = TIMESTAMP_PREFIX;
+		private String encapsulatedTimestamp = ENCAPSULATED_TIMESTAMP_PREFIX;
+		private String keyInfo = KEYINFO_PREFIX;
+		private String value = VALUE_PREFIX;
+		private String xades = XADES_PREFIX;
+
+		public XAdESIdBuilder id(String id) {
+			this.id = id;
+			return this;
+		}
+
+		public XAdESIdBuilder timestamp(String timestamp) {
+			this.timestamp = timestamp;
+			return this;
+		}
+
+		public XAdESIdBuilder encapsulatedTimestamp(String encapsulatedTimestamp) {
+			this.encapsulatedTimestamp = encapsulatedTimestamp;
+			return this;
+		}
+
+		public XAdESIdBuilder keyInfo(String keyInfo) {
+			this.keyInfo = keyInfo;
+			return this;
+		}
+
+		public XAdESIdBuilder value(String value) {
+			this.value = value;
+			return this;
+		}
+
+		public XAdESIdBuilder xades(String xades) {
+			this.xades = xades;
+			return this;
+		}
+
+		public XAdESIdPrefixes build() {
+			return new XAdESIdPrefixes(this);
+		}
+	}
+}

--- a/dss-xades/src/main/java/eu/europa/esig/dss/xades/XAdESSignatureParameters.java
+++ b/dss-xades/src/main/java/eu/europa/esig/dss/xades/XAdESSignatureParameters.java
@@ -178,7 +178,12 @@ public class XAdESSignatureParameters extends AbstractSignatureParameters<XAdEST
 	 */
 	private List<DSSDataObjectFormat> dataObjectFormatList;
 
-	/**
+  /**
+   * Contains all id prefixes used in the signature
+   */
+  private XAdESIdPrefixes xAdESIdPrefixes = XAdESIdPrefixes.newBuilder().build();
+
+  /**
 	 * Default constructor instantiating object with null values
 	 */
 	public XAdESSignatureParameters() {
@@ -653,6 +658,24 @@ public class XAdESSignatureParameters extends AbstractSignatureParameters<XAdEST
 	public void setDataObjectFormatList(List<DSSDataObjectFormat> dataObjectFormatList) {
 		this.dataObjectFormatList = dataObjectFormatList;
 	}
+
+  /**
+   * Retrieves the id prefixes.
+   *
+   * @return  the id prefixes
+   */
+  public XAdESIdPrefixes getPrefixes() {
+    return this.xAdESIdPrefixes;
+  }
+
+  /**
+   * Sets the prefixes for all id:s in the signature.
+   *
+   * @param idPrefixes the prefix definitions
+   */
+  public void setPrefixes(XAdESIdPrefixes idPrefixes) {
+    this.xAdESIdPrefixes = idPrefixes;
+  }
 
 	@Override
 	public XAdESTimestampParameters getContentTimestampParameters() {

--- a/dss-xades/src/main/java/eu/europa/esig/dss/xades/signature/XAdESBuilder.java
+++ b/dss-xades/src/main/java/eu/europa/esig/dss/xades/signature/XAdESBuilder.java
@@ -76,15 +76,6 @@ public abstract class XAdESBuilder {
 	/** The URI attribute */
 	public static final String URI = "URI";
 
-	/** Xml Id prefix */
-	protected static final String ID_PREFIX = "id-";
-
-	/** Id-prefix for TimeStamp element */
-	protected static final String TIMESTAMP_PREFIX = "ts-";
-
-	/** Id-prefix for EncapsulatedTimeStamp element */
-	protected static final String ENCAPSULATED_TIMESTAMP_PREFIX = "ets-";
-
 	/**
 	 * This variable holds the {@code XAdESPaths} which contains all constants and
 	 * queries needed to cope with the default signature schema.
@@ -268,12 +259,12 @@ public abstract class XAdESBuilder {
 	protected void incorporateIssuerV1(final Element parentDom, final CertificateToken certificate) {
 		final Element issuerSerialDom = DomUtils.addElement(documentDom, parentDom, getXadesNamespace(), getCurrentXAdESElements().getElementIssuerSerial());
 		final Element x509IssuerNameDom = DomUtils.addElement(documentDom, issuerSerialDom, getXmldsigNamespace(), XMLDSigElement.X509_ISSUER_NAME);
-				
+
 		final String issuerX500PrincipalName = certificate.getIssuerX500Principal().getName();
 		DomUtils.setTextNode(documentDom, x509IssuerNameDom, issuerX500PrincipalName);
 
 		final Element x509SerialNumberDom = DomUtils.addElement(documentDom, issuerSerialDom, getXmldsigNamespace(), XMLDSigElement.X509_SERIAL_NUMBER);
-		
+
 		final BigInteger serialNumber = certificate.getSerialNumber();
 		final String serialNumberString = serialNumber.toString();
 		DomUtils.setTextNode(documentDom, x509SerialNumberDom, serialNumberString);
@@ -448,7 +439,7 @@ public abstract class XAdESBuilder {
 	 * @return {@link String}
 	 */
 	protected String toXmlIdentifier(Identifier identifier) {
-		return ID_PREFIX + DSSUtils.getSHA1Digest(identifier.asXmlId());
+		return params.getPrefixes().getId() + DSSUtils.getSHA1Digest(identifier.asXmlId());
 	}
 	
 }

--- a/dss-xades/src/main/java/eu/europa/esig/dss/xades/signature/XAdESLevelBaselineT.java
+++ b/dss-xades/src/main/java/eu/europa/esig/dss/xades/signature/XAdESLevelBaselineT.java
@@ -498,7 +498,7 @@ public class XAdESLevelBaselineT extends ExtensionBuilder implements SignatureEx
 				id = timestampToken.getDSSIdAsString();
 			}
 
-			timeStampValidationDataDom.setAttribute("Id", ID_PREFIX + id);
+			timeStampValidationDataDom.setAttribute("Id", params.getPrefixes().getId() + id);
 			if (params.isPrettyPrint()) {
 				DSSXMLUtils.indentAndReplace(documentDom, timeStampValidationDataDom);
 			}
@@ -599,8 +599,8 @@ public class XAdESLevelBaselineT extends ExtensionBuilder implements SignatureEx
 		if (!XAdESNamespace.XADES_111.isSameUri(getXadesNamespace().getUri())) {
 			// Add Id after the element is constructed
 			final String timestampId = toXmlIdentifier(XAdESAttributeIdentifier.build(timeStampDom));
-			timeStampDom.setAttribute(XMLDSigAttribute.ID.getAttributeName(), TIMESTAMP_PREFIX + timestampId);
-			encapsulatedTimeStampDom.setAttribute(XMLDSigAttribute.ID.getAttributeName(), ENCAPSULATED_TIMESTAMP_PREFIX + timestampId);
+			timeStampDom.setAttribute(XMLDSigAttribute.ID.getAttributeName(), params.getPrefixes().getTimestamp() + timestampId);
+			encapsulatedTimeStampDom.setAttribute(XMLDSigAttribute.ID.getAttributeName(), params.getPrefixes().getEncapsulatedTimestamp() + timestampId);
 		}
 	}
 

--- a/dss-xades/src/main/java/eu/europa/esig/dss/xades/signature/XAdESSignatureBuilder.java
+++ b/dss-xades/src/main/java/eu/europa/esig/dss/xades/signature/XAdESSignatureBuilder.java
@@ -132,13 +132,6 @@ public abstract class XAdESSignatureBuilder extends XAdESBuilder implements Sign
 	/** Cached UnsignedSignatureProperties element */
 	protected Element unsignedSignaturePropertiesDom;
 
-	/** Id-prefix for KeyInfo element */
-	protected static final String KEYINFO_PREFIX = "keyInfo-";
-	/** Id-prefix for SignatureValue element */
-	protected static final String VALUE_PREFIX = "value-";
-	/** Id-prefix for Signature element */
-	protected static final String XADES_PREFIX = "xades-";
-
 	/**
 	 * Creates the signature according to the packaging
 	 *
@@ -520,7 +513,7 @@ public abstract class XAdESSignatureBuilder extends XAdESBuilder implements Sign
 		final Element keyInfoElement = DomUtils.createElementNS(documentDom, getXmldsigNamespace(), XMLDSigElement.KEY_INFO);
 		signatureDom.appendChild(keyInfoElement);
 		if (params.isSignKeyInfo()) {
-			keyInfoElement.setAttribute(XMLDSigAttribute.ID.getAttributeName(), KEYINFO_PREFIX + deterministicId);
+			keyInfoElement.setAttribute(XMLDSigAttribute.ID.getAttributeName(), params.getPrefixes().getKeyInfo() + deterministicId);
 		}
 		List<CertificateToken> certificates = new BaselineBCertificateSelector(params.getSigningCertificate(), params.getCertificateChain())
 				.setTrustedCertificateSource(certificateVerifier.getTrustedCertSources())
@@ -731,7 +724,7 @@ public abstract class XAdESSignatureBuilder extends XAdESBuilder implements Sign
 		final Element reference = DomUtils.createElementNS(documentDom, getXmldsigNamespace(), XMLDSigElement.REFERENCE);
 		signedInfoDom.appendChild(reference);	
 		reference.setAttribute(XMLDSigAttribute.TYPE.getAttributeName(), xadesPath.getSignedPropertiesUri());
-		reference.setAttribute(XMLDSigAttribute.URI.getAttributeName(), DomUtils.toElementReference(XADES_PREFIX + deterministicId));
+		reference.setAttribute(XMLDSigAttribute.URI.getAttributeName(), DomUtils.toElementReference(params.getPrefixes().getXades() + deterministicId));
 
 		final Element transforms = DomUtils.createElementNS(documentDom, getXmldsigNamespace(), XMLDSigElement.TRANSFORMS);
 		reference.appendChild(transforms);
@@ -779,7 +772,7 @@ public abstract class XAdESSignatureBuilder extends XAdESBuilder implements Sign
 		
 		final Element reference = DomUtils.createElementNS(documentDom, getXmldsigNamespace(), XMLDSigElement.REFERENCE);
 		signedInfoDom.appendChild(reference);		
-		reference.setAttribute(XMLDSigAttribute.URI.getAttributeName(), DomUtils.toElementReference(KEYINFO_PREFIX + deterministicId));
+		reference.setAttribute(XMLDSigAttribute.URI.getAttributeName(), DomUtils.toElementReference(params.getPrefixes().getKeyInfo() + deterministicId));
 		
 		final Element transforms = DomUtils.createElementNS(documentDom, getXmldsigNamespace(), XMLDSigElement.TRANSFORMS);
 		reference.appendChild(transforms);
@@ -821,7 +814,7 @@ public abstract class XAdESSignatureBuilder extends XAdESBuilder implements Sign
 	protected void incorporateSignatureValue() {
 		signatureValueDom = DomUtils.createElementNS(documentDom, getXmldsigNamespace(), XMLDSigElement.SIGNATURE_VALUE);
 		signatureDom.appendChild(signatureValueDom);		
-		signatureValueDom.setAttribute(XMLDSigAttribute.ID.getAttributeName(), VALUE_PREFIX + deterministicId);
+		signatureValueDom.setAttribute(XMLDSigAttribute.ID.getAttributeName(), params.getPrefixes().getValue() + deterministicId);
 	}
 
 	/**
@@ -835,7 +828,7 @@ public abstract class XAdESSignatureBuilder extends XAdESBuilder implements Sign
 	 */
 	protected void incorporateSignedProperties() {
 		signedPropertiesDom = DomUtils.addElement(documentDom, qualifyingPropertiesDom, getXadesNamespace(), getCurrentXAdESElements().getElementSignedProperties());
-		signedPropertiesDom.setAttribute(XMLDSigAttribute.ID.getAttributeName(), XADES_PREFIX + deterministicId);
+		signedPropertiesDom.setAttribute(XMLDSigAttribute.ID.getAttributeName(), params.getPrefixes().getXades() + deterministicId);
 
 		incorporateSignedSignatureProperties();
 
@@ -1623,9 +1616,9 @@ public abstract class XAdESSignatureBuilder extends XAdESBuilder implements Sign
 		timestampElement.appendChild(encapsulatedTimestampElement);
 
 		// Build Id after time-stamp incorporation to ensure {@code timestampElement} contains a new time-stamp
-		final String timestampId = TIMESTAMP_PREFIX + toXmlIdentifier(XAdESAttributeIdentifier.build(timestampElement));
+		final String timestampId = params.getPrefixes().getTimestamp() + toXmlIdentifier(XAdESAttributeIdentifier.build(timestampElement));
 		timestampElement.setAttribute(XMLDSigAttribute.ID.getAttributeName(), timestampId);
-		encapsulatedTimestampElement.setAttribute(XMLDSigAttribute.ID.getAttributeName(), ENCAPSULATED_TIMESTAMP_PREFIX + timestampId);
+		encapsulatedTimestampElement.setAttribute(XMLDSigAttribute.ID.getAttributeName(), params.getPrefixes().getEncapsulatedTimestamp() + timestampId);
 	}
 
 	/**

--- a/dss-xades/src/test/java/eu/europa/esig/dss/xades/XAdESIdPrefixTest.java
+++ b/dss-xades/src/test/java/eu/europa/esig/dss/xades/XAdESIdPrefixTest.java
@@ -1,0 +1,66 @@
+package eu.europa.esig.dss.xades;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class XAdESIdPrefixTest {
+
+  @Test
+  void getDefaultPrefixes() {
+    XAdESIdPrefixes prefix = XAdESIdPrefixes.newBuilder().build();
+    assertEquals("id-", prefix.getId());
+    assertEquals("ets-", prefix.getEncapsulatedTimestamp());
+    assertEquals("ts-", prefix.getTimestamp());
+    assertEquals("keyInfo-", prefix.getKeyInfo());
+    assertEquals("xades-", prefix.getXades());
+    assertEquals("value-", prefix.getValue());
+  }
+
+  @Test
+  void getChangedPrefixes() {
+    XAdESIdPrefixes prefix =
+        XAdESIdPrefixes.newBuilder()
+            .id("otherid-")
+            .encapsulatedTimestamp("otherets-")
+            .timestamp("otherts-")
+            .keyInfo("otherkeyInfo-")
+            .xades("otherxades-")
+            .value("othervalue-")
+            .build();
+    assertEquals("otherid-", prefix.getId());
+    assertEquals("otherets-", prefix.getEncapsulatedTimestamp());
+    assertEquals("otherts-", prefix.getTimestamp());
+    assertEquals("otherkeyInfo-", prefix.getKeyInfo());
+    assertEquals("otherxades-", prefix.getXades());
+    assertEquals("othervalue-", prefix.getValue());
+  }
+
+  @Test
+  void getPrefixesNeedsToBeUnique() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            XAdESIdPrefixes.newBuilder()
+                .id("otherid-")
+                .encapsulatedTimestamp("otherets-")
+                .timestamp("other-")
+                .keyInfo("other-")
+                .xades("otherxades-")
+                .value("othervalue-")
+                .build());
+  }
+
+	@ParameterizedTest
+	@ValueSource(strings = { "<id-", ">id-", "&id-", "\"id-", "'id-" })
+	void getPrefixesContainsIllegalXmlCharacters(String id) {
+		assertThrows(
+				IllegalArgumentException.class,
+				() ->
+						XAdESIdPrefixes.newBuilder()
+								.id(id)
+								.build(),"Id contains invalid XML character: " + id);
+	}
+}

--- a/dss-xades/src/test/java/eu/europa/esig/dss/xades/signature/CustomizedIdPrefixesTest.java
+++ b/dss-xades/src/test/java/eu/europa/esig/dss/xades/signature/CustomizedIdPrefixesTest.java
@@ -1,0 +1,81 @@
+/**
+ * DSS - Digital Signature Services
+ * Copyright (C) 2015 European Commission, provided under the CEF programme
+ * 
+ * This file is part of the "DSS - Digital Signature Services" project.
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package eu.europa.esig.dss.xades.signature;
+
+import eu.europa.esig.dss.enumerations.SignatureLevel;
+import eu.europa.esig.dss.enumerations.SignaturePackaging;
+import eu.europa.esig.dss.model.DSSDocument;
+import eu.europa.esig.dss.model.FileDocument;
+import eu.europa.esig.dss.signature.DocumentSignatureService;
+import eu.europa.esig.dss.xades.XAdESIdPrefixes;
+import eu.europa.esig.dss.xades.XAdESSignatureParameters;
+import eu.europa.esig.dss.xades.XAdESTimestampParameters;
+import java.util.Date;
+import org.junit.jupiter.api.BeforeEach;
+
+class CustomizedIdPrefixesTest extends AbstractXAdESTestSignature {
+
+	private DocumentSignatureService<XAdESSignatureParameters, XAdESTimestampParameters> service;
+	private XAdESSignatureParameters signatureParameters;
+	private DSSDocument documentToSign;
+
+	@BeforeEach
+	void init() throws Exception {
+		documentToSign = new FileDocument("src/test/resources/sample.xml");
+
+		signatureParameters = new XAdESSignatureParameters();
+		signatureParameters.bLevel().setSigningDate(new Date());
+		signatureParameters.setSigningCertificate(getSigningCert());
+		signatureParameters.setCertificateChain(getCertificateChain());
+		signatureParameters.setSignaturePackaging(SignaturePackaging.ENVELOPED);
+		signatureParameters.setSignatureLevel(SignatureLevel.XAdES_BASELINE_B);
+		signatureParameters.setPrefixes(XAdESIdPrefixes.newBuilder()
+				.id("_id-")
+				.encapsulatedTimestamp("_ets-")
+				.timestamp("_ts-")
+				.keyInfo("_keyInfo-")
+				.xades("_xades-")
+				.value("_value-")
+				.build());
+		service = new XAdESService(getOfflineCertificateVerifier());
+	}
+
+	@Override
+	protected String getSigningAlias() {
+		return GOOD_USER;
+	}
+
+	@Override
+	protected DocumentSignatureService<XAdESSignatureParameters, XAdESTimestampParameters> getService() {
+		return service;
+	}
+
+	@Override
+	protected XAdESSignatureParameters getSignatureParameters() {
+		return signatureParameters;
+	}
+
+	@Override
+	protected DSSDocument getDocumentToSign() {
+		return documentToSign;
+	}
+	
+}


### PR DESCRIPTION
It is now possible to configure the prefixes of
all XAdES signature id:s.